### PR TITLE
orange 다음에 e로 시작하는 단어 추가

### DIFF
--- a/wordlist.txt
+++ b/wordlist.txt
@@ -22,3 +22,4 @@ socks
 status
 sudo
 orange
+energy


### PR DESCRIPTION
y로 시작하는 단어를 추가할 수 있겠군요. 원본 리파지토리(imyaman/kkeun-ma-rit-gi)에 pull request 보내주세요.
